### PR TITLE
Restrict to run for certain builders

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [0.2.3] - 2025-06-17
+
+- Skip copying light/dark images when the Sphinx builder will not use them, which is the case for builders: epub, gettext, latex, linkcheck, man, pseudoxml, texinfo, text, xml.
+
 ## [0.2.2] - 2024-11-26
 
 - Fix: prevent calling method `report_messages` if `HTML5Translator` does not have it. It is here for compat reasons.

--- a/dist/js/sphinx-colorschemed-images.esm.js
+++ b/dist/js/sphinx-colorschemed-images.esm.js
@@ -1,6 +1,6 @@
 /*!
-  * sphinx-colorschemed-images v0.2.1 (https://github.com/danirus/sphinx-colorschemed-images).
-  * Copyright 2024 Daniela Rus Morales.
+  * sphinx-colorschemed-images v0.2.2 (https://github.com/danirus/sphinx-colorschemed-images).
+  * Copyright 2025 Daniela Rus Morales.
   * Licensed under MIT (https://github.com/danirus/sphinx-colorschemed-images/blob/main/LICENSE).
   */
 function _arrayLikeToArray(r, a) {

--- a/dist/js/sphinx-colorschemed-images.js
+++ b/dist/js/sphinx-colorschemed-images.js
@@ -1,6 +1,6 @@
 /*!
-  * sphinx-colorschemed-images v0.2.1 (https://github.com/danirus/sphinx-colorschemed-images).
-  * Copyright 2024 Daniela Rus Morales.
+  * sphinx-colorschemed-images v0.2.2 (https://github.com/danirus/sphinx-colorschemed-images).
+  * Copyright 2025 Daniela Rus Morales.
   * Licensed under MIT (https://github.com/danirus/sphinx-colorschemed-images/blob/main/LICENSE).
   */
 (function (factory) {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,10 +50,7 @@ html_static_path = ['static']
 html_favicon = "static/diamond-half.svg"
 
 html_theme_options = {
-    "documentation_font": "Open Sans",
-    "documentation_font_size": "1.0rem",
-    "monospace_font": "Ubuntu Mono",
-    "monospace_font_size": "1.1rem",
+    "monospace_font_size": ".90rem",
 
     "style": "purple",
     "pygments_light_style": "pastie",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx-colorschemed-images",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Include color-scheme aware images in Sphinx projects.",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ docs = [
     "sphinx-design >=0.6.1, <0.7",
     "sphinx-colorschemed-images >= 0.2.2",
     "sphinx_copybutton >=0.5.2, <1.0.0",
-    "sphinx-nefertiti >=0.7.3",
+    "sphinx-nefertiti >=0.8.2",
 ]
 
 [tool.setuptools]

--- a/sphinx_colorschemed_images/__init__.py
+++ b/sphinx_colorschemed_images/__init__.py
@@ -2,7 +2,7 @@
 
 from .extension import copy_colorschemed_images, extension_builder_inited
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 def setup(app) -> dict:

--- a/sphinx_colorschemed_images/extension.py
+++ b/sphinx_colorschemed_images/extension.py
@@ -178,7 +178,18 @@ def collect_candidates(env, img_path, node):
 
 def copy_colorschemed_images(app, *args):
     """Copy colorschemed_images that were not copied by the HTML Builder."""
-    if not hasattr(app.env, "colorschemed_images"):
+    _skip = [  # Skip this Sphinx builders.
+        "epub",
+        "gettext",
+        "latex",
+        "linkcheck",
+        "man",
+        "pseudoxml",
+        "texinfo",
+        "text",
+        "xml",
+    ]
+    if not hasattr(app.env, "colorschemed_images") or app.builder.name in _skip:
         return
 
     images = dict(app.env.colorschemed_images)


### PR DESCRIPTION
This extension is only useful for those Sphinx builders whose output is interpreted as HTML by a browser. The rest of the builders do not benefit from it. This PR is about making the extension run only under certain Sphinx builders.